### PR TITLE
Add basic unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+2025-05-18 Added unit tests for InternalExtensions
+  - Build failed: unable to restore NuGet packages offline

--- a/DevDistricts.Tests/DevDistricts.Tests.csproj
+++ b/DevDistricts.Tests/DevDistricts.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../DevDistricts/DevDistricts.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/DevDistricts.Tests/InternalExtensionsTests.cs
+++ b/DevDistricts.Tests/InternalExtensionsTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using DevDistricts;
+using DevDistricts.Internal;
+using Xunit;
+
+[District]
+[Occupant(UserName = "test", MachineName = "box")]
+internal class SingleMatchDistrict {}
+
+[District]
+[Occupant(UserName = "amb", MachineName = "box")]
+internal class AmbiguousDistrictA {}
+
+[District]
+[Occupant(UserName = "amb", MachineName = "box")]
+internal class AmbiguousDistrictB {}
+
+public class InternalExtensionsTests
+{
+    [Fact]
+    public void MatchDistrict_Returns_Matching_Type()
+    {
+        var districts = Assembly.GetExecutingAssembly().GetDistricts();
+        var match = districts.MatchDistrict("test", "box");
+        Assert.NotNull(match);
+        Assert.Equal(typeof(SingleMatchDistrict), match.Value.Type);
+    }
+
+    [Fact]
+    public void MatchDistrict_Returns_Null_When_No_Match()
+    {
+        var districts = Assembly.GetExecutingAssembly().GetDistricts();
+        var match = districts.MatchDistrict("none", "none");
+        Assert.Null(match);
+    }
+
+    [Fact]
+    public void MatchDistrict_Throws_For_Ambiguous_Matches()
+    {
+        var districts = Assembly.GetExecutingAssembly().GetDistricts();
+        Assert.Throws<AmbiguousDistrictMatchException>(() => districts.MatchDistrict("amb", "box"));
+    }
+
+    [Theory]
+    [InlineData(typeof(Task))]
+    [InlineData(typeof(Task<int>))]
+    public void IsTask_Returns_True_For_Task_Types(Type t)
+    {
+        Assert.True(InternalExtensions.IsTask(t));
+    }
+
+    [Fact]
+    public void IsTask_Returns_False_For_Non_Task_Type()
+    {
+        Assert.False(InternalExtensions.IsTask(typeof(string)));
+    }
+}

--- a/DevDistricts.sln
+++ b/DevDistricts.sln
@@ -4,19 +4,56 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DevDistricts", "DevDistrict
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestConsole", "TestConsole\TestConsole.csproj", "{88F44BE4-CBF2-4946-B55B-D60389035FAF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DevDistricts.Tests", "DevDistricts.Tests\DevDistricts.Tests.csproj", "{BDAAA156-7A19-4911-9701-34854DE022F5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{D53B1A49-C203-48F9-9770-B33EA30754AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D53B1A49-C203-48F9-9770-B33EA30754AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D53B1A49-C203-48F9-9770-B33EA30754AF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D53B1A49-C203-48F9-9770-B33EA30754AF}.Debug|x64.Build.0 = Debug|Any CPU
+		{D53B1A49-C203-48F9-9770-B33EA30754AF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D53B1A49-C203-48F9-9770-B33EA30754AF}.Debug|x86.Build.0 = Debug|Any CPU
 		{D53B1A49-C203-48F9-9770-B33EA30754AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D53B1A49-C203-48F9-9770-B33EA30754AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D53B1A49-C203-48F9-9770-B33EA30754AF}.Release|x64.ActiveCfg = Release|Any CPU
+		{D53B1A49-C203-48F9-9770-B33EA30754AF}.Release|x64.Build.0 = Release|Any CPU
+		{D53B1A49-C203-48F9-9770-B33EA30754AF}.Release|x86.ActiveCfg = Release|Any CPU
+		{D53B1A49-C203-48F9-9770-B33EA30754AF}.Release|x86.Build.0 = Release|Any CPU
 		{88F44BE4-CBF2-4946-B55B-D60389035FAF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{88F44BE4-CBF2-4946-B55B-D60389035FAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88F44BE4-CBF2-4946-B55B-D60389035FAF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{88F44BE4-CBF2-4946-B55B-D60389035FAF}.Debug|x64.Build.0 = Debug|Any CPU
+		{88F44BE4-CBF2-4946-B55B-D60389035FAF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{88F44BE4-CBF2-4946-B55B-D60389035FAF}.Debug|x86.Build.0 = Debug|Any CPU
 		{88F44BE4-CBF2-4946-B55B-D60389035FAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{88F44BE4-CBF2-4946-B55B-D60389035FAF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{88F44BE4-CBF2-4946-B55B-D60389035FAF}.Release|x64.ActiveCfg = Release|Any CPU
+		{88F44BE4-CBF2-4946-B55B-D60389035FAF}.Release|x64.Build.0 = Release|Any CPU
+		{88F44BE4-CBF2-4946-B55B-D60389035FAF}.Release|x86.ActiveCfg = Release|Any CPU
+		{88F44BE4-CBF2-4946-B55B-D60389035FAF}.Release|x86.Build.0 = Release|Any CPU
+		{BDAAA156-7A19-4911-9701-34854DE022F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BDAAA156-7A19-4911-9701-34854DE022F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BDAAA156-7A19-4911-9701-34854DE022F5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BDAAA156-7A19-4911-9701-34854DE022F5}.Debug|x64.Build.0 = Debug|Any CPU
+		{BDAAA156-7A19-4911-9701-34854DE022F5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BDAAA156-7A19-4911-9701-34854DE022F5}.Debug|x86.Build.0 = Debug|Any CPU
+		{BDAAA156-7A19-4911-9701-34854DE022F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BDAAA156-7A19-4911-9701-34854DE022F5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BDAAA156-7A19-4911-9701-34854DE022F5}.Release|x64.ActiveCfg = Release|Any CPU
+		{BDAAA156-7A19-4911-9701-34854DE022F5}.Release|x64.Build.0 = Release|Any CPU
+		{BDAAA156-7A19-4911-9701-34854DE022F5}.Release|x86.ActiveCfg = Release|Any CPU
+		{BDAAA156-7A19-4911-9701-34854DE022F5}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- set up xUnit test project
- add InternalExtensionsTests covering MatchDistrict and IsTask
- record failing build due to offline restore in CHANGELOG

## Testing
- `dotnet build DevDistricts.Tests/DevDistricts.Tests.csproj --no-restore -v minimal` *(fails: unable to retrieve packages)*