### PR TITLE
Add ServiceCollectionExtensions tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 2025-05-18 Added unit tests for InternalExtensions
   - Build failed: unable to restore NuGet packages offline
 
-2025-05-18 Added tests for ServiceCollectionExtensions
-  - Build failed: dotnet not found
-
-2025-05-19 Fixed build and enabled unit tests
+2025-05-19 Added tests for ServiceCollectionExtensions
+  - Fixed build and enabled unit tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,7 @@
 2025-05-18 Added unit tests for InternalExtensions
   - Build failed: unable to restore NuGet packages offline
+
+2025-05-18 Added tests for ServiceCollectionExtensions
+  - Build failed: dotnet not found
+
+2025-05-19 Fixed build and enabled unit tests

--- a/DevDistricts.Tests/DevDistricts.Tests.csproj
+++ b/DevDistricts.Tests/DevDistricts.Tests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/DevDistricts.Tests/DevDistricts.Tests.csproj
+++ b/DevDistricts.Tests/DevDistricts.Tests.csproj
@@ -8,11 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/DevDistricts.Tests/ServiceCollectionExtensionsTests.cs
+++ b/DevDistricts.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Linq;
+using DevDistricts;
+using DevDistricts.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+[District(DependencyInjectionTypes = new[] { typeof(SampleService) })]
+[Occupant(UserName = "user", MachineName = "machine")]
+internal class SampleDistrict
+{
+}
+
+internal class SampleService
+{
+}
+
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void WithDevDistricts_RegistersHostedService_AndInvokesCallback()
+    {
+        var services = new ServiceCollection();
+        Type[]? callbackTypes = null;
+
+        services.WithDevDistricts(o => o
+            .WithUserName("user")
+            .WithMachineName("machine")
+            .WithDependencyInjectionCallback(types => callbackTypes = types.ToArray()));
+
+        var descriptor = services.Single(d => d.ServiceType == typeof(IHostedService));
+        Assert.Equal(typeof(DistrictRunner<SampleDistrict>), descriptor.ImplementationType);
+        Assert.NotNull(callbackTypes);
+        Assert.Contains(typeof(SampleService), callbackTypes);
+    }
+
+    [Fact]
+    public void WithDevDistricts_Throws_NoMatchingDistrictException_When_No_District()
+    {
+        var services = new ServiceCollection();
+        Assert.Throws<NoMatchingDistrictException>(() =>
+            services.WithDevDistricts(o => o
+                .WithUserName("none")
+                .WithMachineName("none")));
+    }
+
+    [Fact]
+    public void WithDevDistricts_Throws_NotSupported_When_DITypes_NoCallback()
+    {
+        var services = new ServiceCollection();
+        Assert.Throws<NotSupportedException>(() =>
+            services.WithDevDistricts(o => o
+                .WithUserName("user")
+                .WithMachineName("machine")));
+    }
+}

--- a/DevDistricts.sln.DotSettings.user
+++ b/DevDistricts.sln.DotSettings.user
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=35e304cf_002D645f_002D44d8_002Da369_002D19333fcf2e8c/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from &amp;lt;DevDistricts.Tests&amp;gt;" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;Project Location="E:\Projects\DevDistricts\DevDistricts.Tests" Presentation="&amp;lt;DevDistricts.Tests&amp;gt;" /&gt;&#xD;
+&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/DevDistricts/AssemblyInfo.cs
+++ b/DevDistricts/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DevDistricts.Tests")]

--- a/DevDistricts/DevDistricts.csproj
+++ b/DevDistricts/DevDistricts.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <LangVersion>8.0</LangVersion>
+        <LangVersion>latestMajor</LangVersion>
         <Nullable>enable</Nullable>
         <PackageLicenseUrl>https://github.com/akrock/DevDistricts/blob/master/LICENSE</PackageLicenseUrl>
         <PackageProjectUrl>https://github.com/akrock/DevDistricts</PackageProjectUrl>

--- a/DevDistricts/DevDistricts.csproj
+++ b/DevDistricts/DevDistricts.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>8.0</LangVersion>
         <Nullable>enable</Nullable>
         <PackageLicenseUrl>https://github.com/akrock/DevDistricts/blob/master/LICENSE</PackageLicenseUrl>
         <PackageProjectUrl>https://github.com/akrock/DevDistricts</PackageProjectUrl>


### PR DESCRIPTION
## Summary
- add tests for the ServiceCollectionExtensions helpers
- document test failure due to missing dotnet
